### PR TITLE
fix: ajustar layout de projetos no dashboard

### DIFF
--- a/assets/css/dashboard.css
+++ b/assets/css/dashboard.css
@@ -805,20 +805,43 @@ body.tv-mode .section{
 
 
 /* ==========================================================================
-   Projects layout (desktop 2 cols, mobile 1 col)
+   Projects layout
+   - Overview: single column (carousel full width)
+   - Projects tab (desktop): carousel + inline details (2 cols)
+   - Mobile: single column
    ========================================================================== */
+
+/* Default: overview / other tabs */
 .section.projects{
   display:grid;
-  grid-template-columns: 5fr 7fr;
+  grid-template-columns: 1fr;
   gap: var(--space-3);
   align-items:start;
   min-height:0;
 }
-.section.projects #projectsCarousel{ grid-column: 1; }
-.section.projects #projectDetailsInline{ grid-column: 2; min-height:0; }
+.section.projects #projectsCarousel{ grid-column:1; }
+.section.projects #projectDetailsInline{
+  grid-column:1;
+  min-height:0;
+  display:none;
+}
 .section.projects #projectDetailsInline .project-detail-inline{ min-height:0; }
+
+/* Projects tab (desktop): show carousel + details side by side */
+.projects-page .section.projects{
+  grid-template-columns: 5fr 7fr;
+}
+.projects-page .section.projects #projectDetailsInline{
+  grid-column:2;
+  display:block;
+}
+
+/* Mobile: always single column */
 @media (max-width: 900px){
-  .section.projects{ grid-template-columns: 1fr; }
+  .section.projects{ grid-template-columns:1fr; }
+  .projects-page .section.projects{ grid-template-columns:1fr; }
   .section.projects #projectsCarousel,
-  .section.projects #projectDetailsInline{ grid-column: 1; }
+  .section.projects #projectDetailsInline{
+    grid-column:1;
+  }
 }

--- a/assets/js/app/ui.js
+++ b/assets/js/app/ui.js
@@ -156,6 +156,7 @@
           if (els.sectionPill) els.sectionPill.textContent = 'Projetos';
           show('#sectionProjects');
           clearTicketDetail(els);
+          this.renderProjects();
           return;
         }
       },
@@ -278,7 +279,11 @@
             ` : ''}
           `;
 
-          el.addEventListener('click', ()=> UI.openProjectDetailInline(p));
+          el.addEventListener('click', ()=> {
+            UI.openProjectDetailInline(p);
+            document.querySelectorAll('#projectsCarousel .project.selected').forEach(el=>el.classList.remove('selected'));
+            el.classList.add('selected');
+          });
           els.projectsCarousel.appendChild(el);
         });
 
@@ -991,7 +996,9 @@
         setTimeout(()=> UI.updateProjectArrows(), 300);
       },
       openProjectDetailInline(p){
-        UI.setActiveTab('projects');
+        if (!document.body.classList.contains('projects-page')) {
+          UI.setActiveTab('projects');
+        }
         const rdos = DB.state.rdosByProject[p.id] || [];
         if (!els.projDetailsInline) return;
         els.projDetailsInline.innerHTML = `
@@ -1150,15 +1157,7 @@
       closeSidebar();
     });
     els.tabProjects?.addEventListener('click', ()=> {
-      const first = DB.state.projects?.[0];
-      if (first){
-        UI.openProjectDetailInline(first);
-        document.querySelectorAll('#projectsCarousel .project.selected').forEach(el=>el.classList.remove('selected'));
-        const firstCard = document.querySelector('#projectsCarousel .project');
-        firstCard?.classList.add('selected');
-      } else {
-        UI.setActiveTab('projects');
-      }
+      UI.setActiveTab('projects');
       closeSidebar();
     });
     els.tabAdmin?.addEventListener('click', (e)=> {


### PR DESCRIPTION
## Summary
- garantir que o carrossel de projetos ocupe toda a largura na visão geral
- exibir detalhes dos projetos lado a lado apenas na aba de Projetos

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a0af33a7d08330be4141b76fc2d75d