### PR TITLE
feat: show project detail on mobile

### DIFF
--- a/assets/css/mobile.css
+++ b/assets/css/mobile.css
@@ -316,3 +316,28 @@ body.is-mobile{ padding-bottom:0; }
 /* Mantém comportamento de mostrar detalhe quando body tem .show-detail */
 .is-mobile.show-detail.tickets-detail-only #sectionTicketDetail{ display:block !important; }
 
+
+/* ======================================================================
+   MOBILE: Estado 'projects-detail-only' (aplica apenas ao card de Detalhes)
+   ----------------------------------------------------------------------
+   - Esconde a lista de projetos e mostra somente o detalhe
+   - Ajusta largura e rolagem do painel de detalhe
+   ====================================================================== */
+.is-mobile.projects-detail-only #sectionProjects { display:none !important; }
+.is-mobile.projects-detail-only #sectionProjectDetail { display:block !important; }
+
+.is-mobile.projects-detail-only .content.panel {
+  display:flex;
+  flex-direction:column;
+  align-items:stretch !important;
+  overflow:hidden;
+}
+
+.is-mobile.projects-detail-only #sectionProjectDetail .project-detail-inline.panel {
+  width:100% !important;
+  max-width:none !important;
+  min-width:0 !important;
+  margin:0 !important;
+  padding:var(--space-3);
+  overflow-y:auto;
+}

--- a/assets/js/app/ui.js
+++ b/assets/js/app/ui.js
@@ -125,17 +125,21 @@
         setPageState('default');
         adminMenu?.classList.toggle('open', adminMenuOpen);
 
-        document.body.classList.remove('tickets-page','projects-page','tickets-detail-only');
-if (which === 'tickets') {
-  if (APP.state.IS_MOBILE) {
-    document.body.classList.add('tickets-detail-only');
-  } else {
-    document.body.classList.add('tickets-page');
-  }
-}
-if (which === 'projects') {
-  if (!APP.state.IS_MOBILE) document.body.classList.add('projects-page');
-}
+        document.body.classList.remove('tickets-page','projects-page','tickets-detail-only','projects-detail-only');
+        if (which === 'tickets') {
+          if (APP.state.IS_MOBILE) {
+            document.body.classList.add('tickets-detail-only');
+          } else {
+            document.body.classList.add('tickets-page');
+          }
+        }
+        if (which === 'projects') {
+          if (APP.state.IS_MOBILE) {
+            document.body.classList.add('projects-detail-only');
+          } else {
+            document.body.classList.add('projects-page');
+          }
+        }
 
         if(which !== 'overview' && els.projDetailsInline){
           els.projDetailsInline.innerHTML = '';
@@ -165,7 +169,15 @@ if (which === 'projects') {
           els.tabProjects?.classList.add('active');
           if (els.sectionPill) els.sectionPill.textContent = 'Projetos';
           clearTicketDetail(els);
-          if (APP.state.IS_MOBILE) return; // no mobile mantém vazia
+          if (APP.state.IS_MOBILE) {
+            this.renderProjects();
+            const firstProj = DB.state.projects?.[0];
+            if (firstProj) {
+              show('#sectionProjectDetail');
+              this.openProjectDetailInline(firstProj);
+            }
+            return;
+          }
           show('#sectionProjects');
           show('#sectionProjectDetail');
           this.renderProjects();
@@ -1035,7 +1047,7 @@ if (which === 'projects') {
         setTimeout(()=> UI.updateProjectArrows(), 300);
       },
       openProjectDetailInline(p){
-        if (!document.body.classList.contains('projects-page')) {
+        if (!document.body.classList.contains('projects-page') && !APP.state.IS_MOBILE) {
           UI.setActiveTab('projects');
         }
         const rdos = DB.state.rdosByProject[p.id] || [];


### PR DESCRIPTION
## Summary
- add projects-detail-only state to show project detail view on mobile
- render first project detail when switching to projects tab on mobile
- hide project list in mobile layout and adjust detail panel

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a85357cc3c83308769e5c2c5e9de83